### PR TITLE
chore: change default endpoint to use non deprecated version

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -4,7 +4,7 @@ defmodule Airbrakex.Notifier do
   alias Airbrakex.Config
 
   @request_headers [{"Content-Type", "application/json"}]
-  @default_endpoint "https://airbrake.io"
+  @default_endpoint "https://api.airbrake.io"
   @default_env Mix.env()
 
   @info %{


### PR DESCRIPTION

* Since there has been no movement on https://github.com/fazibear/airbrakex/pull/59 I preemptively are updating our fork of the repo so we can start doing this and not scramble near the end of the month. 